### PR TITLE
Prevent "no output destinations active warning"

### DIFF
--- a/sas/hdmacros.sas
+++ b/sas/hdmacros.sas
@@ -1919,7 +1919,7 @@
 %mend;
 
 %macro hd_ReadMacroVariables;
-  PROC SQL;
+  PROC SQL noprint;
     SELECT param_name, param_value
     INTO :param_name1-:param_name150, :param_value1-:param_value150
     FROM hd_parameters;


### PR DESCRIPTION
Correction to hdmacros.sas to prevent "no output destinations active" warning message in the log caused by the internal macro "hd_ReadMacroVariables"